### PR TITLE
Correct path of kf5-sample

### DIFF
--- a/README
+++ b/README
@@ -22,7 +22,7 @@
       you need.
 
     - **For KDE Frameworks ("KF5") / Plasma 5**: Please take a look at 
-      `kdesrc-build-kf5-sample` in the kdesrc-build directory,
+      `kdesrc-buildrc-kf5-sample` in the kdesrc-build directory,
       which gives a starting point example for a suitable ~/.kdesrc-buildrc.
 
     - the `kdesrc-buildrc-sample` file in the kdesrc-build directory


### PR DESCRIPTION
In the directory, it's kdesrc-buildrc-kf5-sample not kdesrc-build-kf5-sample.