### PR TITLE
Let the user choose custom build and source directories

### DIFF
--- a/kdesrc-build-setup
+++ b/kdesrc-build-setup
@@ -237,6 +237,32 @@ else {
     $installDir = "~/kde/usr";
 }
 
+my $buildDir = getMenuOption('Where do you want to build the software?',
+    [
+        home => "$ENV{HOME}/kde/build (default)",
+        custom => "Custom location, chosen next screen",
+    ]);
+
+if ($buildDir eq 'custom') {
+    $buildDir = getDirectory('/usr/local/kde');
+}
+else {
+    $buildDir = "~/kde/build";
+}
+
+my $sourceDir = getMenuOption('Where do you want to source the software?',
+    [
+        home => "$ENV{HOME}/kde/src (default)",
+        custom => "Custom location, chosen next screen",
+    ]);
+
+if ($sourceDir eq 'custom') {
+    $sourceDir = getDirectory('/usr/local/kde');
+}
+else {
+    $sourceDir = "~/kde/src";
+}
+
 my @chosenModules = getListOptions(
     "Which major module groups do you want to build?",
     [
@@ -331,11 +357,11 @@ print $output <<EOF;
     kdedir $installDir
 
     # Directory for downloaded source code
-    source-dir ~/kde/src
+    source-dir $sourceDir
 
     # Directory to build KDE into before installing
     # relative to source-dir by default
-    build-dir ~/kde/build
+    build-dir $buildDir
 
     # Use multiple cores for building. Other options to GNU make may also be
     # set.


### PR DESCRIPTION
My changes let the user choose custom build and source directories. There already was the option to choose a custom install directory, I see no reason why this shouldn't be possible for the build and source directories too.