### PR TITLE
add missing bzr for fedora packages

### DIFF
--- a/modules/ksb/FirstRun.pm
+++ b/modules/ksb/FirstRun.pm
@@ -263,7 +263,7 @@ qrencode-devel
 
 @@ pkg/fedora/unknown
 perl-IO-Socket-SSL perl-JSON-PP perl-YAML-LibYAML perl-IPC-Cmd
-git shared-mime-info make cmake openssl-devel intltool
+git bzr shared-mime-info make cmake openssl-devel intltool
 gcc gcc-c++ python
 mesa-libGL-devel dbus-devel gstreamer1-devel
 polkit-devel


### PR DESCRIPTION
libdbusmenu-qt needs bzr and we forget to put it to fedora packages list