### PR TITLE
Don't force reducing $cores

### DIFF
--- a/modules/ksb/BuildSystem.pm
+++ b/modules/ksb/BuildSystem.pm
@@ -127,12 +127,6 @@ sub buildConstraints
     $cores = 4
         if (int $cores) <= 0;
 
-    # Finally, if user sets cores above what's possible, use 'auto' logic
-    # instead. But let user max out their CPU if they ask specifically for
-    # that.
-    $cores = min($max_cores - 1, $cores)
-        if $cores > $max_cores;
-
     return { compute => $cores };
 }
 


### PR DESCRIPTION
Stop trying to limit $cores to the number of local cores. The system may have more cores available than visible to `nproc`, e.g. due to using distcc.

Only use the number of local cores if specifically requested by setting `num-cores auto`.